### PR TITLE
Implement opentelemetry

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,13 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0" />
     <PackageVersion Include="EFCore.NamingConventions" Version="7.0.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.9" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.9" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.9" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.9" />
+    
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="AutoFixture" Version="4.17.0" />

--- a/Smilodon.sln
+++ b/Smilodon.sln
@@ -17,6 +17,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActivityPub.Domain", "src\A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "src\Domain\Domain.csproj", "{46FC91AA-B4F6-4339-A414-5126474048C6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{98B687E0-157E-4EF0-8482-6E6EDF46E034}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		Directory.Packages.props = Directory.Packages.props
+		nuget.config = nuget.config
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/WebApp/Program.cs
+++ b/src/WebApp/Program.cs
@@ -1,11 +1,35 @@
 using Microsoft.EntityFrameworkCore;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Smilodon.Infrastructure.Persistence;
 using Smilodon.WebApp.Api.Admin;
 using Smilodon.WebApp.Api.Webfinger;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// this should really be in the app config instead...
+const string serviceName = "Smilodon.WebApp";
+const string serviceVersion = "0.0.1";
+
 // Add services to the container.
+
+builder.Services.AddOpenTelemetryTracing(tracerProviderBuilder =>
+{
+    tracerProviderBuilder
+        .AddConsoleExporter()
+        .AddOtlpExporter(opt =>
+        {
+            opt.Protocol = OtlpExportProtocol.HttpProtobuf;
+        })
+        .AddSource(serviceName)
+        .SetResourceBuilder(ResourceBuilder.CreateDefault()
+            .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
+        .AddHttpClientInstrumentation()
+        .AddAspNetCoreInstrumentation()
+        .AddSqlClientInstrumentation();
+});
+
 
 builder.Services.AddControllersWithViews();
 

--- a/src/WebApp/Program.cs
+++ b/src/WebApp/Program.cs
@@ -30,7 +30,6 @@ builder.Services.AddOpenTelemetryTracing(tracerProviderBuilder =>
         .AddSqlClientInstrumentation();
 });
 
-
 builder.Services.AddControllersWithViews();
 
 // Add the database context to the DI container
@@ -38,7 +37,6 @@ builder.Services.AddDbContext<SmilodonDbContext>(options =>
     options
         .UseNpgsql("Host=localhost; Database=smilodon; User Id=smilodon; Password=smilodon;")
         .UseSnakeCaseNamingConvention());
-
 
 var app = builder.Build();
 

--- a/src/WebApp/WebApp.csproj
+++ b/src/WebApp/WebApp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -8,6 +8,15 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootNamespace>Smilodon.WebApp</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />


### PR DESCRIPTION
# Pull Request Template

## Description

Implements basic OpenTelemetry support.

Additionally, I created a "Solution Items" folder and moved all the random project files (gitignore, nuget config, etc) into it to make them easily accessible in Visual Studio.

Note that currently the OpenTelemetry packages are 1.0.0 *prerelease* versions, so we'll want to track that and upgrade when they're released.

We probably need to give some additional thought to configuration and I will open an issue for that. Once we sort out configuration I would also like to make the OTel support, as well as the exporter, be configurable on/off. Currently it should be both writing to console *and* attempting send to the default collector at localhost:4318/ which is the default; I haven't been able to test this yet since getting a local OpenTelemetry stack with Jaeger and Zipkin running is surprisingly non-trivial due to poor documentation. I am tempted to set up a collector (easy and well documented) and test shipping to the Honeycomb free tier.

Fixes #32 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Configured OTel in the WebApp program.cs, tested that I get console logging for OTel when starting up the application. Also tried hitting the webfinger URL which confirmed that OTel logs activity data when hitting a URL. This is all using preconfigured logging, no custom spans or activities.

**Test Configuration**:
* Hardware: Ryzen 7 2700, Windows 11 22H2
* Toolchain: dotnet 7, JetBrains Rider

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
